### PR TITLE
Fix spelling mistake on index.html

### DIFF
--- a/assignment4/web/tpl/index.html
+++ b/assignment4/web/tpl/index.html
@@ -119,7 +119,7 @@
                     <td>{$hotelgwport|default:"N/A"}</td>
                 </tr>
                 <tr>
-                    <td>paperadress</td>
+                    <td>paperaddress</td>
                     <td>{$paperaddress|default:"N/A"}</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
There was a spelling mistake on the index.html page. "paper address" was missing a "d".
